### PR TITLE
Add reset password functionality

### DIFF
--- a/backend/app/api/util.py
+++ b/backend/app/api/util.py
@@ -13,6 +13,8 @@ from app.db_models.image_storage import Image
 import bcrypt
 import jwt
 import datetime
+import string
+import secrets
 from functools import wraps
 from typing import Callable
 from pydantic import BaseModel
@@ -163,3 +165,8 @@ def jwt_token_required(f):
         return await f(*args, **kwargs)
 
     return decorated_function
+
+def generate_email_code(length=8):
+    characters = string.ascii_letters + string.digits
+    email_code = ''.join(secrets.choice(characters) for i in range(length))
+    return email_code

--- a/backend/app/api_models/auth.py
+++ b/backend/app/api_models/auth.py
@@ -61,7 +61,6 @@ class LoginResponse(BaseModel):
     token_type: str
     user_id: int
 
-
 class UserResponse(BaseModel):
     id: int
 
@@ -83,3 +82,44 @@ class UserResponse(BaseModel):
 
 class UsersResponse(BaseModel):
     users: list[UserResponse]
+
+class ForgetPasswordRequest(BaseModel):
+    login: str
+
+class ForgetPasswordResponse(BaseModel):
+    msg: str = "Email sent successfuly"
+
+class LoginWithCodeRequest(BaseModel):
+    """
+    A class representing a login via code request.
+
+    Attributes
+    ----------
+    login : str
+        The username or email used for login.
+    code : str
+        The code received from the email.
+    """
+
+    login: str
+    code: str
+
+class LoginWithCodeResponse(BaseModel):
+    """
+        class LoginResponse(BaseModel):
+            access_token: str
+            token_type: str
+            user_id: int
+
+        Attributes
+        ----------
+        access_token : str
+            The token provided to the user for authentication purposes.
+        token_type : str
+            The type of token issued, e.g., Bearer.
+        user_id : int
+            The unique identifier of the user.
+    """
+    access_token: str
+    token_type: str
+    user_id: int

--- a/backend/app/api_models/profile.py
+++ b/backend/app/api_models/profile.py
@@ -65,6 +65,11 @@ class ModifyProfileRequest(BaseModel):
                 raise ValueError(f"Each interest must be less than {MAX_TAG_LENGTH} characters")
         return value
 
-
 class ModifyProfileResponse(BaseModel):
+    message: str = "Profile updated successfully"
+
+class ChangePasswordRequest(BaseModel):
+    new_password: str
+
+class ChangePasswordResponse(BaseModel):
     message: str = "Profile updated successfully"

--- a/backend/app/db_models/chats.py
+++ b/backend/app/db_models/chats.py
@@ -37,6 +37,9 @@ class User(DBBase):
     login = Column(String, nullable=False)
     password_hashed = Column(String, nullable=False)
 
+    email_code = Column(String, nullable=True, default=None)
+    email_code_expiry = Column(DateTime, nullable=True, default=None)
+
     image_id: Mapped[int | None] = mapped_column(ForeignKey("images.id"))
 
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,34 @@
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from textwrap import dedent
+
+def send_reset_code_to_email(to_address, name, reset_code):
+    smtp_server = "smtp.gmail.com"
+    smtp_port = 587
+    sender_email = "nconnectnoreply@gmail.com"
+    sender_password = "lywr iigp itmh kfbg" 
+
+    try:
+        msg = MIMEMultipart()
+        msg['From'] = sender_email
+        msg['To'] = to_address
+        msg['Subject'] = "NeighbourhoodConnect password reset"
+
+        msg.attach(MIMEText(
+          dedent(f"""\
+          Dear {name}, You are receiving this e-mail because you have requested to have your password reset for your account at Neighbourhood Connect. 
+          
+          Please use the following code to access you account: {reset_code}. Please note, that this code will only be valid for the next hour.
+          
+          Thank you for your attention.
+
+          Neighbourhood Connect
+          """), 'plain'))
+
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            server.starttls() 
+            server.login(sender_email, sender_password) 
+            server.send_message(msg) 
+    except Exception as e:
+        print(f"Failed to send email. Error: {str(e)}")

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -805,6 +805,90 @@
                 }
             }
         },
+        "/auth/forget_password": {
+            "post": {
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Forget Password",
+                "description": "Send a password reset code to the user's registered email.\n\n:param request: The ForgetPasswordRequest object containing the user's login information.\n:return: A ForgetPasswordResponse indicating the email was successfully sent.\n:raises HTTPException: If the user does not exist or if an error occurs while generating or sending the code.",
+                "operationId": "forget_password_auth_forget_password_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ForgetPasswordRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ForgetPasswordResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/login_with_code": {
+            "post": {
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Login With Code",
+                "description": "Log in a user using a previously generated email code.\n\n:param form_data: The form data containing the username (login) and the code sent to the user's email.\n:raises HTTPException: If the user does not exist, the code is incorrect, or the code has expired.",
+                "operationId": "login_with_code_auth_login_with_code_post",
+                "requestBody": {
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_login_with_code_auth_login_with_code_post"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LoginWithCodeResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/offers/": {
             "post": {
                 "tags": [
@@ -1218,6 +1302,53 @@
                 ]
             }
         },
+        "/users/change_password/": {
+            "post": {
+                "tags": [
+                    "users"
+                ],
+                "summary": "Change Password",
+                "description": "Change the password of the authenticated user.\n\n:param request: The current request being processed.\n:param profile_request: A ChangePasswordRequest object containing the new password.\n:return: A ChangePasswordResponse indicating that the profile was updated successfully.\n:raises HTTPException: If the user does not exist or there is an error during password change.",
+                "operationId": "change_password_users_change_password__post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ChangePasswordRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChangePasswordResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ]
+            }
+        },
         "/users/users": {
             "get": {
                 "tags": [
@@ -1385,6 +1516,63 @@
                 ],
                 "title": "Body_login_auth_login_post"
             },
+            "Body_login_with_code_auth_login_with_code_post": {
+                "properties": {
+                    "grant_type": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "password"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Grant Type"
+                    },
+                    "username": {
+                        "type": "string",
+                        "title": "Username"
+                    },
+                    "password": {
+                        "type": "string",
+                        "title": "Password"
+                    },
+                    "scope": {
+                        "type": "string",
+                        "title": "Scope",
+                        "default": ""
+                    },
+                    "client_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Client Id"
+                    },
+                    "client_secret": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Client Secret"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "username",
+                    "password"
+                ],
+                "title": "Body_login_with_code_auth_login_with_code_post"
+            },
             "Body_store_image_image_storage__post": {
                 "properties": {
                     "file": {
@@ -1402,6 +1590,30 @@
                     "image_type"
                 ],
                 "title": "Body_store_image_image_storage__post"
+            },
+            "ChangePasswordRequest": {
+                "properties": {
+                    "new_password": {
+                        "type": "string",
+                        "title": "New Password"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "new_password"
+                ],
+                "title": "ChangePasswordRequest"
+            },
+            "ChangePasswordResponse": {
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "title": "Message",
+                        "default": "Profile updated successfully"
+                    }
+                },
+                "type": "object",
+                "title": "ChangePasswordResponse"
             },
             "CreateChatRequest": {
                 "properties": {
@@ -1807,6 +2019,30 @@
                 "type": "object",
                 "title": "EditOfferDataResponse"
             },
+            "ForgetPasswordRequest": {
+                "properties": {
+                    "login": {
+                        "type": "string",
+                        "title": "Login"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "login"
+                ],
+                "title": "ForgetPasswordRequest"
+            },
+            "ForgetPasswordResponse": {
+                "properties": {
+                    "msg": {
+                        "type": "string",
+                        "title": "Msg",
+                        "default": "Email sent successfuly"
+                    }
+                },
+                "type": "object",
+                "title": "ForgetPasswordResponse"
+            },
             "Gender": {
                 "type": "string",
                 "enum": [
@@ -2139,6 +2375,30 @@
                     "user_id"
                 ],
                 "title": "LoginResponse",
+                "description": "class LoginResponse(BaseModel):\n    access_token: str\n    token_type: str\n    user_id: int\n\nAttributes\n----------\naccess_token : str\n    The token provided to the user for authentication purposes.\ntoken_type : str\n    The type of token issued, e.g., Bearer.\nuser_id : int\n    The unique identifier of the user."
+            },
+            "LoginWithCodeResponse": {
+                "properties": {
+                    "access_token": {
+                        "type": "string",
+                        "title": "Access Token"
+                    },
+                    "token_type": {
+                        "type": "string",
+                        "title": "Token Type"
+                    },
+                    "user_id": {
+                        "type": "integer",
+                        "title": "User Id"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "access_token",
+                    "token_type",
+                    "user_id"
+                ],
+                "title": "LoginWithCodeResponse",
                 "description": "class LoginResponse(BaseModel):\n    access_token: str\n    token_type: str\n    user_id: int\n\nAttributes\n----------\naccess_token : str\n    The token provided to the user for authentication purposes.\ntoken_type : str\n    The type of token issued, e.g., Bearer.\nuser_id : int\n    The unique identifier of the user."
             },
             "Message": {


### PR DESCRIPTION
Add three APIs functions for 

1. Change password, when user is already logged in. This function receives only new_password.
2. Forget password, when user wants to log into his account via email. This function receives user login, fetches the email form database, generates code and sends an email to user for him to enter it to the next function.
3. Login with code. This function is used to grant user access to his account using code, which he received to the email. It works exactly like default login function, but uses codes, instead of hashed password.

Here's the screenshots of mentioned functions:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/e35f5484-10c5-4d43-905c-fb7084786ea8">
<img width="399" alt="image" src="https://github.com/user-attachments/assets/cc154d93-74ed-43db-9c65-90632efa966e">
<img width="480" alt="image" src="https://github.com/user-attachments/assets/b12b89c0-a45d-458b-adfe-fbbd9d1d3fa9">
